### PR TITLE
Feat: 엔티티 수정 및 post mapper구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+.metadata
 
 ### STS ###
 .apt_generated

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.2.0</version>
         </dependency>
+        <!-- Model Mapper : DTO와 Entity 호환 API -->
+		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>2.4.0</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/src/main/java/com/geumjjok/comment/model/entity/Comment.java
+++ b/src/main/java/com/geumjjok/comment/model/entity/Comment.java
@@ -20,7 +20,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,46 +32,41 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "comment")
 @Hidden
 public class Comment {
-	
+
 	@Id
-	@Column(name = "comment_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private int commentId;
 
 	@NonNull
-	@Column(name = "content", columnDefinition = "TEXT", nullable = false)
+	@Column(columnDefinition = "TEXT", nullable = false)
 	private String content;
 
-	@Column(name = "created_at")
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	@Column(name = "updated_at")
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 
-	@Column(name = "is_deleted", columnDefinition = "boolean default false")
+	@Column(columnDefinition = "boolean default false")
 	private boolean isDeleted;
-	
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "post_id", nullable = false)
-	private Post postId; // Post 엔티티와의 관계 매핑
-	
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
+	@JoinColumn(nullable = false)
+	private Post postId; // Post 엔티티와의 관계 매핑
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(nullable = false)
 	private Member memberId;
-	
+
 	@Builder
 	public Comment(@NonNull String content, Post postId, Member memberId) {
 		this.content = content;
 		this.postId = postId;
 		this.memberId = memberId;
 	}
-	
+
 	public String getCreatedAtAsString() {
 		return formatDateTime(this.createdAt);
 	}

--- a/src/main/java/com/geumjjok/like/model/entity/PostLike.java
+++ b/src/main/java/com/geumjjok/like/model/entity/PostLike.java
@@ -31,34 +31,30 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "post_like")
 @Hidden
 public class PostLike {
 	
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "like_id")
 	private int likeId;
 
-	@Column(name = "created_at")
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	@Column(name = "updated_at")
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 
-	@Column(name = "is_deleted", columnDefinition = "boolean default false")
+	@Column(columnDefinition = "boolean default false")
 	private boolean isDeleted;
 	
 	@NonNull
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name="post_id", nullable = false)
+	@JoinColumn(nullable = false)
 	private Post postId;
 
 	@NonNull
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name="member_id", nullable = false)
+	@JoinColumn(nullable = false)
 	private Member memberId;
 
 	@Override

--- a/src/main/java/com/geumjjok/member/model/entity/Member.java
+++ b/src/main/java/com/geumjjok/member/model/entity/Member.java
@@ -1,21 +1,10 @@
 package com.geumjjok.member.model.entity;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import com.geumjjok.comment.model.entity.Comment;
-import com.geumjjok.like.model.entity.PostLike;
-import com.geumjjok.post.model.entity.Post;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.persistence.Column;
@@ -24,29 +13,23 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @RequiredArgsConstructor
 @Getter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "member")
 @Hidden
 public class Member {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "member_id")
 	private int memberId;
 
 	@NonNull
@@ -54,7 +37,7 @@ public class Member {
 	private String name;
 
 	@NonNull
-	@Column(name = "nick_name", length = 20, nullable = false)
+	@Column(length = 20, nullable = false)
 	private String nickName;
 
 	@NonNull
@@ -65,30 +48,18 @@ public class Member {
 	@Column(length = 50, nullable = false)
 	private String email;
 
-	@Column(name = "created_at")
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	@Column(name = "updated_at")
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 
-	@Column(name = "is_deleted", columnDefinition = "boolean default false")
+	@Column(columnDefinition = "boolean default false")
 	private boolean isDeleted;
-
-	@OneToMany(mappedBy = "memberId")
-	private List<Post> posts = new ArrayList<>();
-
-	@OneToMany(mappedBy = "memberId")
-	private List<Comment> comments = new ArrayList<>();
-
-	@OneToMany(mappedBy = "memberId")
-	private List<PostLike> likes = new ArrayList<>();
 
 	@Builder
 	public Member(int memberId, @NonNull String name, @NonNull String nickName, @NonNull String password,
-			@NonNull String email, LocalDateTime createdAt, LocalDateTime updatedAt, boolean isDeleted,
-			List<Post> posts, List<Comment> comments, List<PostLike> likes) {
+			@NonNull String email, LocalDateTime createdAt, LocalDateTime updatedAt, boolean isDeleted) {
 		this.memberId = memberId;
 		this.name = name;
 		this.nickName = nickName;
@@ -97,9 +68,6 @@ public class Member {
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
 		this.isDeleted = isDeleted;
-		this.posts = posts;
-		this.comments = comments;
-		this.likes = likes;
 	}
 
 	@Override

--- a/src/main/java/com/geumjjok/post/controller/PostController.java
+++ b/src/main/java/com/geumjjok/post/controller/PostController.java
@@ -28,39 +28,22 @@ public class PostController {
 
 	@Autowired
 	private PostService postService;
-	
-//	@GetMapping("/list") // 게시글 목록 조회
-//	public ModelAndView postList() {
-//		ModelAndView mav = new ModelAndView();
-//	    List<PostDTO> posts = postService.findPostList();
-//	    mav.addObject("posts", posts);
-//	    mav.setViewName("post/list");
-//	    return mav;
-//	}
 
 	@GetMapping("/list") // 게시글 목록 조회
 	public List<PostDTO> postList() {
 		return postService.findPostList();
 	}
 
-//	@GetMapping("/detail/{postId}") // 게시글 상세 조회
-//	public PostDTO postDetails(@PathVariable int postId) {
-//		System.out.println("postDetails");
-//		return postService.findPostDetails(postId);
-//	}
-	
 	@GetMapping("/detail/{postId}") // 게시글 상세 조회
 	public ResponseEntity<?> postDetails(@PathVariable int postId) {
-	    System.out.println("postDetails");
-	    try {
-	        PostDTO postDTO = postService.findPostDetails(postId);
-	        return ResponseEntity.ok(postDTO);
-	    } catch (PostNotFoundException e) {
-	        e.printStackTrace();
-	        return ResponseEntity
-	                .status(HttpStatus.NOT_FOUND)
-	                .body(e.getMessage());
-	    }
+		System.out.println("postDetails");
+		try {
+			PostDTO postDTO = postService.findPostDetails(postId);
+			return ResponseEntity.ok(postDTO);
+		} catch (PostNotFoundException e) {
+			e.printStackTrace();
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+		}
 	}
 
 	@PostMapping() // 게시글 등록

--- a/src/main/java/com/geumjjok/post/model/PostDTO.java
+++ b/src/main/java/com/geumjjok/post/model/PostDTO.java
@@ -1,5 +1,9 @@
 package com.geumjjok.post.model;
 
+import java.util.List;
+
+import com.geumjjok.comment.model.CommentDTO;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,11 +20,13 @@ import lombok.ToString;
 public class PostDTO {
 	private int postId;
 
-	private String memberName;
+	private String memberNickName;
 
 	private String title;
 
 	private String content;
+	
+	private List<CommentDTO> comments;
 
 	private String createdAt;
 

--- a/src/main/java/com/geumjjok/post/model/entity/Post.java
+++ b/src/main/java/com/geumjjok/post/model/entity/Post.java
@@ -5,7 +5,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -26,7 +25,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,13 +38,11 @@ import lombok.RequiredArgsConstructor;
 @DynamicUpdate
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "post")
 @Hidden
 public class Post {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "post_id")
 	private int postId;
 
 	@NonNull
@@ -57,23 +53,21 @@ public class Post {
 	@Column(columnDefinition = "TEXT", nullable = false)
 	private String content;
 
-	@Column(name = "created_at")
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	@Column(name = "updated_at")
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 
-	@Column(name = "is_deleted", columnDefinition = "boolean default false")
+	@Column(columnDefinition = "boolean default false")
 	private boolean isDeleted;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
+	@JoinColumn(nullable = false)
 	private Member memberId;
 
 	@OneToMany(mappedBy = "postId", cascade = jakarta.persistence.CascadeType.REMOVE) // CascadeType.REMOVE 게시판 삭제 ->  댓글도 삭
-	private List<Comment> comments = new ArrayList<>();;
+	private List<Comment> comments = new ArrayList<>();
 
 	@OneToMany(mappedBy = "postId")
 	private List<PostLike> likes = new ArrayList<>();
@@ -95,10 +89,6 @@ public class Post {
 
 	public String getUpdatedAtAsString() {
 		return formatDateTime(this.updatedAt);
-	}
-
-	public String getMemberName(Member member) {
-		return member != null ? member.getName() : null;
 	}
 
 	private String formatDateTime(LocalDateTime dateTime) {

--- a/src/main/java/com/geumjjok/post/model/mapper/PostMapper.java
+++ b/src/main/java/com/geumjjok/post/model/mapper/PostMapper.java
@@ -1,0 +1,38 @@
+package com.geumjjok.post.model.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.geumjjok.comment.model.CommentDTO;
+import com.geumjjok.comment.model.entity.Comment;
+import com.geumjjok.post.model.PostDTO;
+import com.geumjjok.post.model.entity.Post;
+
+public class PostMapper {
+
+	public static PostDTO toPostDTO(Post post) {
+		if (post == null) {
+			return null;
+		}
+
+		List<CommentDTO> commentDTOs = post.getComments().stream().map(PostMapper::toCommentDTO)
+				.collect(Collectors.toList());
+
+		return PostDTO.builder().postId(post.getPostId())
+				.memberNickName(post.getMemberId() != null ? post.getMemberId().getNickName() : null).title(post.getTitle())
+				.content(post.getContent()).comments(commentDTOs).createdAt(post.getCreatedAtAsString())
+				.updatedAt(post.getUpdatedAtAsString()).isDeleted(post.isDeleted()).build();
+	}
+
+	private static CommentDTO toCommentDTO(Comment comment) {
+		if (comment == null) {
+			return null;
+		}
+
+		String memberNickName = comment.getMemberId() != null ? comment.getMemberId().getNickName() : null;
+		int postId = comment.getPostId() != null ? comment.getPostId().getPostId() : null;
+
+		return new CommentDTO(comment.getCommentId(), memberNickName, postId, comment.getContent(),
+				comment.getCreatedAtAsString(), comment.getUpdatedAtAsString(), comment.isDeleted());
+	}
+}

--- a/src/main/java/com/geumjjok/post/model/service/PostService.java
+++ b/src/main/java/com/geumjjok/post/model/service/PostService.java
@@ -14,6 +14,7 @@ import com.geumjjok.post.exception.PostNotFoundException;
 import com.geumjjok.post.model.PostDTO;
 import com.geumjjok.post.model.PostRequestDTO;
 import com.geumjjok.post.model.entity.Post;
+import com.geumjjok.post.model.mapper.PostMapper;
 import com.geumjjok.post.model.repository.PostRepository;
 
 @Service
@@ -26,7 +27,7 @@ public class PostService {
 
 	private PostDTO convertToDto(Post post) {
 		return PostDTO.builder().postId(post.getPostId()).title(post.getTitle()).content(post.getContent())
-				.memberName(post.getMemberName(post.getMemberId())).createdAt(post.getCreatedAtAsString())
+				.memberNickName(post.getMemberId().getNickName()).createdAt(post.getCreatedAtAsString())
 				.updatedAt(post.getUpdatedAtAsString()).isDeleted(post.isDeleted()).build();
 	}
 
@@ -38,7 +39,7 @@ public class PostService {
 	public PostDTO findPostDetails(int postId) throws PostNotFoundException {
 		Post post = postRepository.findById(postId)
 				.orElseThrow(() -> new PostNotFoundException("존재하지 않는 게시글 ID 입니다: " + postId));
-		return convertToDto(post);
+		return PostMapper.toPostDTO(post);
 	}
 
 	public PostDTO addPost(PostRequestDTO postRequestDTO) {
@@ -51,7 +52,6 @@ public class PostService {
 	public void removePost(int postId) throws PostNotFoundException {
 		Post post = postRepository.findPostByPostIdAndIsDeletedIsFalse(postId)
 				.orElseThrow(() -> new PostNotFoundException("존재하지 않는 게시글 ID 입니다: " + postId));
-		System.out.println(post);
 		post.updateIsDeleted();
 	}
 


### PR DESCRIPTION
- 모든 도메인 엔티티 @column() 에서 camel case 변수명 -> snake case로 변환하는 코드 삭제 -> spring data jpa는 자동으로 변환
- Member 엔티티에서 연관관계 매핑 모두 삭제
- PostMapper 정의하여 Post 상세 조회 시 comment 리스트 매핑하도록 구현
